### PR TITLE
Add code block formatting for Python example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ interactive_chat(agent)
 
 ## How It Works
 
+```python
 try:
     z = ZAPI(
         client_id="invalid", 


### PR DESCRIPTION
- Introduced a code block for the ZAPI initialization example to enhance readability and clarity for users.
- Ensured consistent formatting throughout the documentation for better user experience.

<img width="1089" height="594" alt="Screenshot 2025-11-11 at 12 46 01 AM" src="https://github.com/user-attachments/assets/5cccba6b-03f3-4314-b654-c747d8d27d0e" />
