### PR TITLE
Update documentation to clarify LLM model name usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cp .env.example .env
      # Required environment variables
      LLM_API_KEY=your_llm_api_key_here
      LLM_PROVIDER=anthropic                    # anthropic, openai, google, groq
-     LLM_MODEL_NAME=claude-3-5-sonnet-20241022 # model name for your provider
+     LLM_MODEL_NAME=your_model_name_here      # Use the latest available model for your provider
      ADOPT_CLIENT_ID=your_client_id_here       # Get from app.adopt.ai
      ADOPT_SECRET_KEY=your_secret_key_here     # Get from app.adopt.ai
      YOUR_API_URL=your_api_url_here            # Custom API URL
@@ -139,7 +139,7 @@ z = ZAPI()
 
 # Check configuration
 print(f"Provider: {z.get_llm_provider()}")        # 'anthropic'
-print(f"Model: {z.get_llm_model_name()}")         # 'claude-3-5-sonnet-20241022'
+print(f"Model: {z.get_llm_model_name()}")         # Your configured model name
 print(f"Has key: {z.has_llm_key()}")              # True
 
 # Update LLM configuration after initialization
@@ -158,7 +158,7 @@ try:
         client_id="invalid",
         secret="invalid",
         llm_provider="anthropic",
-        llm_model_name="claude-3-5-sonnet-20241022",
+        llm_model_name="your-model-name",  # Use the latest available model for your provider
         llm_api_key="invalid-key"
     )
 except ZAPIAuthenticationError as e:
@@ -286,7 +286,7 @@ ZAPI will load the file automatically, hide secret values in logs, and apply the
 
 - `client_id` / `secret`: OAuth credentials from Adopt AI.
 - `llm_provider`: `"groq"`, `"anthropic"`, `"openai"`, or `"google"`.
-- `llm_model_name`: Any model identifier your provider supports (e.g., `"claude-3-5-sonnet-20241022"`, `"gpt-4"`).
+- `llm_model_name`: Any model identifier your provider supports. Use the latest available model for your provider (e.g., check your provider's documentation for current model names).
 - `llm_api_key`: Provider-specific API key (encrypted immediately per organization context).
 
 Key methods:

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -37,7 +37,7 @@ ZAPI uses OAuth authentication with the adopt.ai platform and supports LLM integ
 - A `secret` key
 - An LLM `provider` (anthropic, openai, google, or groq)
 - An LLM `api_key` for your chosen provider
-- An LLM `model_name` (e.g., "claude-3-5-sonnet-20241022")
+- An LLM `model_name` (use the latest available model for your provider - check your provider's documentation for current model names)
 
 **Getting your client_id and secret:**
 Sign up at [app.adopt.ai](https://app.adopt.ai) to get your OAuth credentials.
@@ -57,7 +57,7 @@ z = ZAPI(
     secret="YOUR_SECRET",
     llm_provider="anthropic",
     llm_api_key="sk-ant-YOUR_API_KEY",
-    llm_model_name="claude-3-5-sonnet-20241022"
+    llm_model_name="your-model-name"  # Use the latest available model for your provider
 )
 
 # Launch browser and capture traffic
@@ -83,7 +83,7 @@ You can also load credentials from a `.env` file:
 # Create .env file with your credentials
 echo "LLM_PROVIDER=anthropic" >> .env
 echo "LLM_API_KEY=sk-ant-your-key-here" >> .env
-echo "LLM_MODEL_NAME=claude-3-5-sonnet-20241022" >> .env
+echo "LLM_MODEL_NAME=your-model-name" >> .env  # Use the latest available model for your provider
 ```
 
 Run the demo script to verify everything works:
@@ -114,7 +114,7 @@ z = ZAPI(
     secret="YOUR_SECRET",
     llm_provider="anthropic",
     llm_api_key="sk-ant-your-key",  # Encrypted automatically
-    llm_model_name="claude-3-5-sonnet-20241022"
+    llm_model_name="your-model-name"  # Use the latest available model for your provider
 )
 
 # Check if LLM key is configured
@@ -135,7 +135,7 @@ z = ZAPI(
     secret="YOUR_SECRET",
     llm_provider="anthropic",
     llm_api_key="sk-ant-YOUR_API_KEY",
-    llm_model_name="claude-3-5-sonnet-20241022"
+    llm_model_name="your-model-name"  # Use the latest available model for your provider
 )
 
 # Capture traffic
@@ -344,7 +344,7 @@ if input("Upload? (y/n): ").lower() == 'y':
 - `client_id` (str): OAuth client ID for authentication
 - `secret` (str): OAuth secret key
 - `llm_provider` (str): LLM provider name ("anthropic", "openai", "google", "groq")
-- `llm_model_name` (str): LLM model name (e.g., "claude-3-5-sonnet-20241022")
+- `llm_model_name` (str): LLM model name. Use the latest available model for your provider (check your provider's documentation for current model names)
 - `llm_api_key` (str): LLM API key for the specified provider
 - Raises `ZAPIValidationError` if credentials are empty or LLM key format is invalid
 - Raises `ZAPIAuthenticationError` if authentication fails
@@ -461,7 +461,7 @@ playwright install
 # Set up your .env file with credentials
 echo "LLM_PROVIDER=anthropic" >> .env
 echo "LLM_API_KEY=sk-ant-your-key" >> .env
-echo "LLM_MODEL_NAME=claude-3-5-sonnet-20241022" >> .env
+echo "LLM_MODEL_NAME=your-model-name" >> .env  # Use the latest available model for your provider
 
 python demo.py
 ```

--- a/examples/langchain/README.md
+++ b/examples/langchain/README.md
@@ -107,7 +107,7 @@ z = ZAPI()
 
 # 2. Create agent with ZAPI tools
 agent = create_agent(
-    z.get_llm_model_name(),      # Gets the LLM model (e.g., "claude-3-5-sonnet-20241022")
+    z.get_llm_model_name(),      # Gets the LLM model (use the latest available model for your provider)
     z.get_zapi_tools(),           # Gets all your documented APIs as tools
     system_prompt="You are a helpful assistant with access to APIs."
 )


### PR DESCRIPTION
- Changed instances of specific model names to a generic placeholder in README.md, introduction.md, and langchain example README.md.
- Emphasized the importance of using the latest available model for the chosen provider in the documentation.