### PR TITLE
Update environment variable instructions in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Thank you for your interest in contributing to ZAPI! This document provides guid
 5. Set up your environment variables:
 
    ```bash
-   cp .env.example .env
+   cp .devenv .env
    # Edit .env with your credentials from app.adopt.ai
    ```
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Use this as a map when extending ZAPI or debugging the flow.
 2. Copy the example environment file and add your secrets:
 
 ```bash
-cp .env.example .env
+cp .devenv .env
 ```
 
 2. **Set up your environment:**


### PR DESCRIPTION
- Changed references from .env.example to .devenv in both CONTRIBUTING.md and README.md for consistency in setup instructions.
